### PR TITLE
Add window title according to implementation

### DIFF
--- a/main.c
+++ b/main.c
@@ -55,9 +55,6 @@ int main(void)
 
     db_init(&db, display, window);
 
-    XWindowAttributes wa = {0};
-    XGetWindowAttributes(display, window, &wa);
-
     Atom wm_delete_window = XInternAtom(display, "WM_DELETE_WINDOW", False);
     XSetWMProtocols(display, window, &wm_delete_window, 1);
 

--- a/main.c
+++ b/main.c
@@ -55,6 +55,8 @@ int main(void)
 
     db_init(&db, display, window);
 
+    XStoreName(display, window, "DB Implementation: "DB_IMPL_NAME);
+
     Atom wm_delete_window = XInternAtom(display, "WM_DELETE_WINDOW", False);
     XSetWMProtocols(display, window, &wm_delete_window, 1);
 


### PR DESCRIPTION
Makes it easier to keep track of which implementation windows you're looking at if you have multiple open.